### PR TITLE
mvn install; note on system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To build and install the Java wrapper from source, please try the following comm
 % mvn clean install
 ```
 
+Please note you need to have gcc, cmake and libnative installed.
+
 ## Usage
 
 See [SentencePieceProcessorTest](src/test/java/com/github/google/sentencepiece/SentencePieceProcessorTest.java) for more.

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.oleeo.di.tika.GherkinServerCli</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,14 +69,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>com.oleeo.di.tika.GherkinServerCli</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Hi
Only two rather minor changes:
* in order for `mvn install` to install in the local maven repo, you need the maven-jar-plugin
* mention in README; perhaps obvious, but easy to miss: you need to set JAVA_HOME, and have the c/c++ build system installed.