### PR TITLE
Create platform-dependent artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you're trying to build on Windows, you need to specify the Windows-compatible
 % mvn -f pom-windows.xml clean install
 ```
 
+## Using sentencepiece-jni as a dependency
+
+Because the resulting JAR is platform-dependent, resolving this dependency is managed by the [os-maven-plugin](https://github.com/trustin/os-maven-plugin). Follow the instructions there to use this platform-dependent JAR.
+
 Please note you need to have a C++ compiler and cmake installed.
 
 ## Usage

--- a/pom-windows.xml
+++ b/pom-windows.xml
@@ -28,6 +28,7 @@
         <plugins>
             <plugin>
                <artifactId>maven-jar-plugin</artifactId>
+               <version>3.1.0</version>          
                <configuration>
                     <classifier>${os.detected.classifier}</classifier>
                 </configuration>
@@ -85,11 +86,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom-windows.xml
+++ b/pom-windows.xml
@@ -18,7 +18,20 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.1</version>
+            </extension>
+        </extensions>
         <plugins>
+            <plugin>
+               <artifactId>maven-jar-plugin</artifactId>
+               <configuration>
+                    <classifier>${os.detected.classifier}</classifier>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <plugins>
             <plugin>
                <artifactId>maven-jar-plugin</artifactId>
+               <version>3.1.0</version>
                <configuration>
                     <classifier>${os.detected.classifier}</classifier>
                 </configuration>
@@ -77,11 +78,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,20 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.1</version>
+            </extension>
+        </extensions>
         <plugins>
+            <plugin>
+               <artifactId>maven-jar-plugin</artifactId>
+               <configuration>
+                    <classifier>${os.detected.classifier}</classifier>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Consumers of sentencepiece-jni need to depend on an artifact that is compatible with their desired platform. This PR seeks to add a discriminating `classifier` to the build which allows a user to specify which platform they're targetting a la [os-maven-plugin](https://github.com/trustin/os-maven-plugin). This has implications on current users as they will need to explicitly add the platform they were targeting before a cross-platform build was enabled (i.e., `linux-x86_64`).