### PR TITLE
add publishing stub for GitHub Packages.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    strategy:
+      max-parallel: 10
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [8, 9, 10, 11]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -152,5 +152,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/levyfan/sentencepiece-jni</url>
+        </repository>
+    </distributionManagement>
 </project>
 


### PR DESCRIPTION
Seeks to address #16. Currently does this by invoking the publish workflow when a release is created per [docs](https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-java-packages-with-maven). This would rely on @levyfan to maintain some release structure on this repo which hopefully shouldn't be too involved.