### PR TITLE
release only run on jdk8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [8, 9, 10, 11]
+        java: [8]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Current release will produce lots of packages on jdk8/9/10/11 which is redundant. Ideally we only need 3 jars (linux, macos, windows).

sentencepiece-0.0.1-20210119.022957-1-linux-x86_64.jar
sentencepiece-0.0.1-20210119.022957-1.pom
sentencepiece-0.0.1-20210119.023000-2-linux-x86_64.jar
sentencepiece-0.0.1-20210119.023000-2.pom
sentencepiece-0.0.1-20210119.023019-3-linux-x86_64.jar
sentencepiece-0.0.1-20210119.023019-3.pom
sentencepiece-0.0.1-20210119.023025-4-linux-x86_64.jar
sentencepiece-0.0.1-20210119.023025-4.pom
sentencepiece-0.0.1-20210119.023132-5-windows-x86_64.jar
sentencepiece-0.0.1-20210119.023132-5.pom
sentencepiece-0.0.1-20210119.023148-6-osx-x86_64.jar
sentencepiece-0.0.1-20210119.023148-6.pom
sentencepiece-0.0.1-20210119.023154-7-osx-x86_64.jar
sentencepiece-0.0.1-20210119.023154-7.pom
sentencepiece-0.0.1-20210119.023209-8-windows-x86_64.jar
sentencepiece-0.0.1-20210119.023209-8.pom
sentencepiece-0.0.1-20210119.023244-9-osx-x86_64.jar
sentencepiece-0.0.1-20210119.023244-9.pom
sentencepiece-0.0.1-20210119.023259-10-osx-x86_64.jar
sentencepiece-0.0.1-20210119.023259-10.pom
sentencepiece-0.0.1-20210119.023444-11-windows-x86_64.jar
sentencepiece-0.0.1-20210119.023444-11.pom
sentencepiece-0.0.1-20210119.023515-12-windows-x86_64.jar
sentencepiece-0.0.1-20210119.023515-12.pom