### PR TITLE
prepare for 0.0.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.levyfan</groupId>
     <artifactId>sentencepiece</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
prevents a SNAPSHOT with non-determinstic version string from being generated. :-)