### PR TITLE
prep for v0.0.2 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.levyfan</groupId>
     <artifactId>sentencepiece</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This seeks to replace the 0.0.1 release which was accidentally released as a SNAPSHOT. :-) Once this is released we can cut  over to 0.0.3-SNAPSHOT in preparation for 0.0.3.